### PR TITLE
Version lock p5.play


### DIFF
--- a/dodge/index.html
+++ b/dodge/index.html
@@ -32,7 +32,7 @@
             <h3>Instructions</h3>
             <p>Watch out! Use the left and right arrow keys to move Prophet Orpheus around the screen and avoid the meteors!</p>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.8/p5.js"></script>
-            <script src="https://cdn.rawgit.com/molleindustria/p5.play/master/lib/p5.play.js"></script>
+            <script src="https://cdn.rawgit.com/molleindustria/p5.play/1bf3c72fe6b647617373b9b3ea3e419baaef8cfd/lib/p5.play.js"></script>
             <script src="game.js"></script>
             <hr>
         <p>Copyright 2017 | Dalton Craven | Check me out on <a href="https://github.com/cravend/">GitHub</a>!</p>

--- a/platform/index.html
+++ b/platform/index.html
@@ -32,7 +32,7 @@
             <h3>Instructions</h3>
             <p>Use the up arrow key to jump or fly over the blocks. Your score is calculated by how many blocks you pass. Good luck!</p>
             <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.8/p5.min.js"></script>
-            <script type="text/javascript" src="https://cdn.rawgit.com/molleindustria/p5.play/master/lib/p5.play.js"></script>
+            <script type="text/javascript" src="https://cdn.rawgit.com/molleindustria/p5.play/1bf3c72fe6b647617373b9b3ea3e419baaef8cfd/lib/p5.play.js"></script>
             <script type="text/javascript" src="game.js"></script>
             <hr>
             <p>Copyright 2017 | Dalton Craven | Check me out on <a href="https://github.com/cravend/">GitHub</a>!</p>


### PR DESCRIPTION
Hey! I'm one of the engineers at [Hack Club](https://hackclub.com). Right now you're site is broken because it links to the most recent version of p5.play.js, but when that updates your site won't work. I made this edit to set p5.play.js to a specific version so it won't update automatically (and should always work with your site).

Just click the "Merge" button that looks like this down below if you want to accept the edit:

![](https://i.imgur.com/Vz3I4Oi.png)

_This PR is created by a script for people who have completed Hack Club's workshops. If you think it was sent to you in error go ahead and click "close"._
